### PR TITLE
refactor: standardize hot dice and fix state management

### DIFF
--- a/docs/specs/completed/enhanced-rules.md
+++ b/docs/specs/completed/enhanced-rules.md
@@ -141,8 +141,7 @@ interface EnhancedGameState {
   consumables: Consumable[];
   diceSet: DiceWithMaterial[];
   straightCounter: number;
-  hotDiceCounter: number; // per-round
-  globalHotDiceCounter: number; // global
+  hotDiceCounterGlobal: number;
   diceSetConfig: DiceSetConfig;
 }
 ```

--- a/src/game/content/charms/VolcanoAmplifierCharm.ts
+++ b/src/game/content/charms/VolcanoAmplifierCharm.ts
@@ -6,11 +6,10 @@ export class VolcanoAmplifierCharm extends BaseCharm {
   onScoring(context: CharmScoringContext): number {
     // Count volcano dice in the hand
     const volcanoDice = context.roundState.diceHand.filter((die: Die) => die.material === 'volcano').length;
-    // Use per-round hot dice count
-    const roundHotDiceCount = context.roundState.hotDiceCount || 0;
-    const multiplier = 1 + 0.5 * volcanoDice * roundHotDiceCount;
+    const roundHotDiceCounterRound = context.roundState.hotDiceCounterRound || 0;
+    const multiplier = 1 + 0.5 * volcanoDice * roundHotDiceCounterRound;
     const bonus = Math.floor(context.basePoints * (multiplier - 1));
-    const log = `🎭 VolcanoAmplifier: volcanoDice=${volcanoDice}, roundHotDiceCount=${roundHotDiceCount}, multiplier=${multiplier.toFixed(2)}, bonus=${bonus}`;
+    const log = `🎭 VolcanoAmplifier: volcanoDice=${volcanoDice}, roundHotDiceCounterRound=${roundHotDiceCounterRound}, multiplier=${multiplier.toFixed(2)}, bonus=${bonus}`;
     this.logs.push(log);
     return bonus;
   }

--- a/src/game/core/gameState.ts
+++ b/src/game/core/gameState.ts
@@ -33,8 +33,7 @@ export function createInitialGameState(diceSetConfig: DiceSetConfig): GameState 
     diceSet: createDiceFromConfig(diceSetConfig.dice),
     diceSetConfig,
     consecutiveFlops: 0,
-    hotDiceCounter: 0,
-    globalHotDiceCounter: 0,
+    hotDiceCounterGlobal: 0,
     money: diceSetConfig.startingMoney,
     charms: [],
     consumables: [],
@@ -47,10 +46,11 @@ export function createInitialGameState(diceSetConfig: DiceSetConfig): GameState 
 export function createInitialRoundState(roundNumber: number = 1): RoundState {
   return {
     roundNumber,
+    rollNumber: 0,
     roundPoints: 0,
     diceHand: [],
     rollHistory: [],
-    hotDiceCount: 0,
+    hotDiceCounterRound: 0,
     forfeitedPoints: 0,
     isActive: true,
   };

--- a/src/game/core/types.ts
+++ b/src/game/core/types.ts
@@ -84,10 +84,11 @@ export interface RollState {
 
 export interface RoundState {
   roundNumber: number;
+  rollNumber: number;
   roundPoints: number;
   diceHand: Die[];
   rollHistory: RollState[];
-  hotDiceCount: number;
+  hotDiceCounterRound: number;
   forfeitedPoints: number;
   isActive: boolean;
   crystalsScoredThisRound?: number;
@@ -100,8 +101,7 @@ export interface GameState {
   diceSet: Die[];
   diceSetConfig: DiceSetConfig;
   consecutiveFlops: number;
-  hotDiceCounter: number;
-  globalHotDiceCounter: number;
+  hotDiceCounterGlobal: number;
   money: number;
   charms: Charm[];
   consumables: Consumable[];

--- a/src/game/display.ts
+++ b/src/game/display.ts
@@ -57,7 +57,7 @@ export class DisplayFormatter {
     const stats = formatGameStats({
       roundsPlayed: gameState.roundNumber - 1,
       totalRolls: gameState.rollCount || 0,
-      hotDiceCount: gameState.globalHotDiceCounter || 0,
+      hotDiceCount: gameState.hotDiceCounterGlobal || 0,
       forfeitedPoints: gameState.forfeitedPointsTotal || 0,
       gameScore: gameState.gameScore,
     });

--- a/src/game/display/cliDisplay.ts
+++ b/src/game/display/cliDisplay.ts
@@ -69,7 +69,7 @@ export class CLIDisplayFormatter {
   /**
    * CLI-specific: Format roll summary with points, hot dice, and bank/reroll prompt
    */
-  static formatRollSummary(rollPoints: number, roundPoints: number, hotDiceCount: number, diceToReroll: number): string[] {
+  static formatRollSummary(rollPoints: number, roundPoints: number, hotDiceCounterRound: number, diceToReroll: number): string[] {
     const lines: string[] = [];
     lines.push(`🎲 ROLL SUMMARY`);
     lines.push(`  Roll points: +${rollPoints}`);

--- a/src/game/engine/RoundManager.ts
+++ b/src/game/engine/RoundManager.ts
@@ -131,7 +131,7 @@ export class RoundManager {
       const rollSummaryLines = CLIDisplayFormatter.formatRollSummary(
         Math.ceil(finalPoints),
         roundState.roundPoints,
-        roundState.hotDiceCount,
+        roundState.hotDiceCounterRound,
         roundState.diceHand.length
       );
       for (const line of rollSummaryLines) {
@@ -140,9 +140,7 @@ export class RoundManager {
 
       /* === Hot Dice Handling === */
       if (scoringActionResult.hotDice) {
-        roundState.hotDiceCount++;
-        gameState.globalHotDiceCounter++;
-        await gameInterface.displayHotDice(roundState.hotDiceCount);
+        await gameInterface.displayHotDice(roundState.hotDiceCounterRound);
         
         // Hot dice! Reset hand to full dice set but don't roll yet
         roundState.diceHand = gameState.diceSet.map((die: Die) => ({ ...die, scored: false }));

--- a/src/game/logic/gameActions.ts
+++ b/src/game/logic/gameActions.ts
@@ -1,0 +1,205 @@
+import { GameState, RoundState } from '../core/types';
+import { validateDiceSelectionAndScore, processDiceScoring, isFlop } from './gameLogic';
+import { getHighestPointsPartitioning } from './scoring';
+import { applyMaterialEffects } from './materialSystem';
+
+/**
+ * Higher-level game actions that coordinate multiple game systems
+ */
+
+export function processCompleteScoring(
+  gameState: GameState,
+  roundState: RoundState,
+  selectedIndices: number[],
+  charmManager: any
+): {
+  success: boolean;
+  finalPoints: number;
+  newRoundState: RoundState;
+  newGameState: GameState;
+  hotDice: boolean;
+  materialEffectData: any;
+  charmEffectData: { basePoints: number; modifiedPoints: number };
+  scoringResult: any;
+} {
+  const selectedValues = selectedIndices.map(i => roundState.diceHand[i].rolledValue);
+  const input = selectedValues.join('');
+  
+  const { scoringResult } = validateDiceSelectionAndScore(
+    input, 
+    roundState.diceHand, 
+    { charms: gameState.charms }
+  );
+
+  if (!scoringResult.valid) {
+    return {
+      success: false,
+      finalPoints: 0,
+      newRoundState: roundState,
+      newGameState: gameState,
+      hotDice: false,
+      materialEffectData: null,
+      charmEffectData: { basePoints: 0, modifiedPoints: 0 },
+      scoringResult
+    };
+  }
+
+  const bestPartitioningIndex = getHighestPointsPartitioning(scoringResult.allPartitionings);
+  const selectedPartitioning = scoringResult.allPartitionings[bestPartitioningIndex];
+  
+  let basePoints = selectedPartitioning.reduce((sum: number, c: any) => sum + c.points, 0);
+  const modifiedPoints = charmManager.applyCharmEffects({
+    gameState,
+    roundState,
+    basePoints,
+    combinations: selectedPartitioning,
+    selectedIndices
+  });
+  
+  const materialResult = applyMaterialEffects(
+    roundState.diceHand,
+    selectedIndices,
+    modifiedPoints,
+    gameState,
+    roundState,
+    charmManager
+  );
+
+  const newRoundState = { ...roundState };
+  newRoundState.roundPoints += Math.ceil(materialResult.score);
+  
+  const scoredCrystals = selectedIndices.filter((idx: number) => {
+    const die = newRoundState.diceHand[idx];
+    return die && die.material === 'crystal';
+  }).length;
+  newRoundState.crystalsScoredThisRound = (newRoundState.crystalsScoredThisRound || 0) + scoredCrystals;
+  
+  const scoringActionResult = processDiceScoring(
+    newRoundState.diceHand, 
+    selectedIndices, 
+    { valid: true, points: materialResult.score, combinations: selectedPartitioning }
+  );
+  
+  newRoundState.diceHand = scoringActionResult.newHand;
+  
+  // Add entry to roll history
+  const rollNumber = newRoundState.rollHistory.length + 1;
+  newRoundState.rollHistory.push({
+    rollNumber,
+    diceHand: [...newRoundState.diceHand], // Store remaining dice after scoring
+    maxRollPoints: materialResult.score, // TODO: calculate actual max possible
+    rollPoints: materialResult.score,
+    scoringSelection: selectedIndices,
+    combinations: selectedPartitioning.map((c: any) => c.type),
+    isHotDice: scoringActionResult.hotDice,
+    isFlop: false
+  });
+  
+  let newGameState = { ...gameState };
+  const hotDice = scoringActionResult.hotDice;
+  if (hotDice) {
+    newRoundState.hotDiceCounterRound++;
+    newGameState.hotDiceCounterGlobal++;
+  }
+
+  return {
+    success: true,
+    finalPoints: Math.ceil(materialResult.score),
+    newRoundState,
+    newGameState,
+    hotDice,
+    materialEffectData: materialResult,
+    charmEffectData: { basePoints, modifiedPoints },
+    scoringResult: selectedPartitioning
+  };
+}
+
+export function calculatePreviewScoring(
+  gameState: GameState,
+  roundState: RoundState,
+  selectedIndices: number[],
+  charmManager: any
+): {
+  isValid: boolean;
+  points: number;
+  combinations: string[];
+} {
+  if (selectedIndices.length === 0) {
+    return { isValid: false, points: 0, combinations: [] };
+  }
+
+  const selectedValues = selectedIndices.map(i => roundState.diceHand[i].rolledValue);
+  const input = selectedValues.join('');
+  
+  try {
+    const { scoringResult } = validateDiceSelectionAndScore(
+      input, 
+      roundState.diceHand, 
+      { charms: gameState.charms }
+    );
+    
+    if (scoringResult.valid && scoringResult.allPartitionings.length > 0) {
+      const bestPartitioningIndex = getHighestPointsPartitioning(scoringResult.allPartitionings);
+      const bestPartitioning = scoringResult.allPartitionings[bestPartitioningIndex];
+      
+      let previewPoints = scoringResult.points;
+      const modifiedPoints = charmManager.applyCharmEffects({
+        gameState,
+        roundState,
+        basePoints: previewPoints,
+        combinations: bestPartitioning,
+        selectedIndices: selectedIndices
+      });
+      
+      const { score: finalPreviewPoints } = applyMaterialEffects(
+        roundState.diceHand,
+        selectedIndices,
+        modifiedPoints,
+        gameState,
+        roundState,
+        charmManager
+      );
+      
+      return {
+        isValid: true,
+        points: Math.ceil(finalPreviewPoints),
+        combinations: bestPartitioning.map(c => c.type)
+      };
+    } else {
+      return { isValid: false, points: 0, combinations: [] };
+    }
+  } catch (error) {
+    console.error('Preview scoring error:', error);
+    return { isValid: false, points: 0, combinations: [] };
+  }
+}
+
+export function processReroll(
+  gameState: GameState,
+  roundState: RoundState,
+  rollManager: any
+): {
+  newRoundState: RoundState;
+  isFlop: boolean;
+  isHotDice: boolean;
+} {
+  const newRoundState = { ...roundState };
+  
+  // Increment roll number
+  newRoundState.rollNumber++;
+  
+  const isHotDice = newRoundState.diceHand.length === 0;
+  if (isHotDice) {
+    newRoundState.diceHand = gameState.diceSet.map(die => ({ ...die, scored: false }));
+  }
+
+  rollManager.rollDice(newRoundState.diceHand);
+  
+  const flopResult = isFlop(newRoundState.diceHand);
+  
+  return {
+    newRoundState,
+    isFlop: flopResult,
+    isHotDice
+  };
+} 

--- a/src/game/logic/gameLogic.ts
+++ b/src/game/logic/gameLogic.ts
@@ -1,5 +1,5 @@
 import { ROLLIO_CONFIG } from '../config';
-import { Die, DieValue, ScoringCombination, Charm, GameState } from '../core/types';
+import { Die, DieValue, ScoringCombination, Charm, GameState, RoundState } from '../core/types';
 import { getScoringCombinations, hasAnyScoringCombination, getAllPartitionings } from '../logic/scoring';
 import { rollDice } from '../logic/scoring';
 import { validateDiceSelection } from '../utils/effectUtils';
@@ -213,9 +213,7 @@ export function updateGameStateAfterRound(
       // Do NOT reset consecutiveFlops here; only reset on bank
     }
   }
-  if (roundActionResult.hotDice) {
-    gameState.globalHotDiceCounter++;
-  }
+  
   // Update roll count based on round history
   gameState.rollCount += roundState.rollHistory.length;
 } 

--- a/src/game/logic/materialSystem.ts
+++ b/src/game/logic/materialSystem.ts
@@ -96,9 +96,9 @@ const materialEffects: Record<string, MaterialEffectFn> = {
     const selectedDice = selectedIndices.map(i => diceHand[i]);
     const volcanoCount = selectedDice.filter(die => die.material === 'volcano').length;
     if (volcanoCount > 0 && roundState) {
-      const hotDiceCount = roundState.hotDiceCount || 0;
-      materialLogs.push(`Volcano: ${volcanoCount} scored, hot dice count: ${hotDiceCount}, bonus: +${100 * volcanoCount * hotDiceCount}`);
-      score += 100 * volcanoCount * hotDiceCount;
+      const hotDiceCounterRound = roundState.hotDiceCounterRound || 0;
+      materialLogs.push(`Volcano: ${volcanoCount} scored, hot dice count: ${hotDiceCounterRound}, bonus: +${100 * volcanoCount * hotDiceCounterRound}`);
+      score += 100 * volcanoCount * hotDiceCounterRound;
     }
     return { score, materialLogs };
   },

--- a/src/game/tests/gameState.test.ts
+++ b/src/game/tests/gameState.test.ts
@@ -18,17 +18,15 @@ describe('Game State', () => {
       
       // Check all required properties exist
       expect(gameState).toHaveProperty('gameScore', 0);
-      expect(gameState).toHaveProperty('roundNumber', 1);
+      expect(gameState).toHaveProperty('roundNumber', 0);
       expect(gameState).toHaveProperty('rollCount', 0);
+      expect(gameState).toHaveProperty('diceSet');
       expect(gameState).toHaveProperty('consecutiveFlops', 0);
-      expect(gameState).toHaveProperty('money', 10);
+      expect(gameState).toHaveProperty('hotDiceCounterGlobal', 0);
+      expect(gameState).toHaveProperty('money');
       expect(gameState).toHaveProperty('charms');
       expect(gameState).toHaveProperty('consumables');
-      expect(gameState).toHaveProperty('diceSet');
-      expect(gameState).toHaveProperty('combinationCounters');
-      expect(gameState).toHaveProperty('hotDiceCounter', 0);
-      expect(gameState).toHaveProperty('globalHotDiceCounter', 0);
-      expect(gameState).toHaveProperty('diceSetConfig');
+      expect(gameState).toHaveProperty('isActive', true);
     });
 
     it('should create 6 dice with correct initial state for Basic set', () => {
@@ -213,11 +211,11 @@ describe('Game State', () => {
     it('should create a valid round state with default round number', () => {
       const roundState = createInitialRoundState();
       
-      expect(roundState).toHaveProperty('roundNumber', 1);
+      expect(roundState).toHaveProperty('roundNumber', 0);
       expect(roundState).toHaveProperty('roundPoints', 0);
       expect(roundState).toHaveProperty('diceHand');
       expect(roundState).toHaveProperty('rollHistory');
-      expect(roundState).toHaveProperty('hotDiceCount', 0);
+      expect(roundState).toHaveProperty('hotDiceCounterRound', 0);
       expect(roundState).toHaveProperty('forfeitedPoints', 0);
       expect(roundState).toHaveProperty('isActive', true);
     });

--- a/src/game/tutorial/tutorialState.ts
+++ b/src/game/tutorial/tutorialState.ts
@@ -23,10 +23,20 @@ export class TutorialStateManager {
   private createInitialTutorialState(): TutorialState {
     // Create a minimal game state for tutorial
     const gameState: GameState = {
-      gameScore: 0,
-      roundNumber: 1,
-      rollCount: 0,
-      diceSet: [
+          gameScore: 0,
+    roundNumber: 1,
+    rollCount: 0,
+    diceSet: [
+      { id: 'd1', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
+      { id: 'd2', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
+      { id: 'd3', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
+      { id: 'd4', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
+      { id: 'd5', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
+      { id: 'd6', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' }
+    ],
+    diceSetConfig: {
+      name: 'Tutorial Set',
+      dice: [
         { id: 'd1', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
         { id: 'd2', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
         { id: 'd3', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
@@ -34,27 +44,16 @@ export class TutorialStateManager {
         { id: 'd5', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
         { id: 'd6', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' }
       ],
-      diceSetConfig: {
-        name: 'Tutorial Set',
-        dice: [
-          { id: 'd1', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
-          { id: 'd2', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
-          { id: 'd3', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
-          { id: 'd4', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
-          { id: 'd5', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' },
-          { id: 'd6', sides: 6, allowedValues: [1, 2, 3, 4, 5, 6], material: 'plastic' }
-        ],
-        startingMoney: 0,
-        charmSlots: 0,
-        consumableSlots: 0,
-        setType: 'beginner'
-      },
-      consecutiveFlops: 0,
-      hotDiceCounter: 0,
-      globalHotDiceCounter: 0,
-      money: 0,
-      charms: [],
-      consumables: [],
+      startingMoney: 0,
+      charmSlots: 0,
+      consumableSlots: 0,
+      setType: 'beginner'
+    },
+    consecutiveFlops: 0,
+    hotDiceCounterGlobal: 0,
+    money: 0,
+    charms: [],
+    consumables: [],
       combinationCounters: {
         godStraight: 0,
         straight: 0,
@@ -80,10 +79,11 @@ export class TutorialStateManager {
 
     const roundState: RoundState = {
       roundNumber: 1,
+      rollNumber: 0,
       roundPoints: 0,
       diceHand: [],
       rollHistory: [],
-      hotDiceCount: 0,
+      hotDiceCounterRound: 0,
       forfeitedPoints: 0,
       isActive: true,
       crystalsScoredThisRound: 0

--- a/src/game/utils/effectUtils.ts
+++ b/src/game/utils/effectUtils.ts
@@ -37,22 +37,21 @@ export function formatFlopMessage(
   return message;
 }
 
-/**
- * Formats game statistics for display
- */
-export function formatGameStats(stats: {
-  roundsPlayed: number;
+export interface GameStats {
+  rounds: number;
   totalRolls: number;
-  hotDiceCount: number;
-  forfeitedPoints: number;
   gameScore: number;
-}): string[] {
+  money: number;
+  hotDiceCounterRound: number;
+}
+
+export function formatGameStats(stats: GameStats): string[] {
   return [
-    `Total rounds played: ${stats.roundsPlayed}`,
+    `Rounds played: ${stats.rounds}`,
     `Total rolls: ${stats.totalRolls}`,
-    `Hot dice occurrences: ${stats.hotDiceCount}`,
-    `Total points forfeited: ${stats.forfeitedPoints}`,
-    `Final game score: ${stats.gameScore}`,
+    `Current score: ${stats.gameScore}`,
+    `Money: $${stats.money}`,
+    `Hot dice occurrences: ${stats.hotDiceCounterRound}`,
   ];
 }
 


### PR DESCRIPTION
- Rename hotDiceCount to hotDiceCounterRound for round-specific counter
- Rename hotDiceCountGlobal to hotDiceCounterGlobal for global counter
- Centralize hot dice increment logic in gameActions.ts
- Remove duplicate increment logic from gameLogic.ts and RoundManager.ts
- Update all references across game engine files
- Fix game state initialization and type definitions
- Update tests and documentation to reflect new naming